### PR TITLE
fix special characters

### DIFF
--- a/latexify/templates/latexify/scripts.html
+++ b/latexify/templates/latexify/scripts.html
@@ -15,7 +15,7 @@
     function latex_render_math(elements, displayMode){
         for (var i = 0; i < elements.length; ++i) {
             var element = elements[i];
-            var math_eq = element.innerHTML;
+            var math_eq = element.textContent;
             katex.render(math_eq, element, {displayMode: displayMode,
                                             throwOnError: false,
                                             errorColor: '#bf2626'});


### PR DESCRIPTION
Node.innerHTML represents things like < > & etc. as their HTML encodings. Meanwhile .textContent parses these back into their true forms so KaTeX proper can process properly. 